### PR TITLE
Production Build size optimization

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ const config = {
     open: true
   },
 
-  devtool: 'inline-source-map'
+  devtool: 'cheap-module-source-map'
 
 };
 


### PR DESCRIPTION
Source map type change for lower production build size. Almost 400% size loss from about 800KB to ~200KB